### PR TITLE
Fix for character row ids

### DIFF
--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -11,7 +11,7 @@ test_that("Filtering an empty Task (#39)", {
   f$calculate(task)
   expect_numeric(f$scores, names = "unique", len = 0)
 
-  task = mlr_tasks$get("mtcars")$filter(character())
+  task = mlr_tasks$get("mtcars")$filter(integer())
   f = mlr_filters$get("variance")
   f$calculate(task)
   expect_numeric(f$scores, names = "unique", len = length(task$feature_names))

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -11,7 +11,8 @@ test_that("Filtering an empty Task (#39)", {
   f$calculate(task)
   expect_numeric(f$scores, names = "unique", len = 0)
 
-  task = mlr_tasks$get("mtcars")$filter(integer())
+  no_ids = task$row_ids[0]
+  task = mlr_tasks$get("mtcars")$filter(no_ids)
   f = mlr_filters$get("variance")
   f$calculate(task)
   expect_numeric(f$scores, names = "unique", len = length(task$feature_names))


### PR DESCRIPTION
The next mlr3 version will only support integer row ids.
mlr3filters is currently blocking this with a test.