### PR TITLE
Fix praznik scores

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,5 +76,6 @@ Collate:
     'FilterRelief.R'
     'FilterVariance.R'
     'flt.R'
+    'helper.R'
     'reexports.R'
     'zzz.R'

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -39,7 +39,8 @@ Filter = R6Class("Filter",
     #' @field scores
     #'   Stores the calculated filter score values as named numeric vector.
     #'   The vector is sorted in decreasing order with possible `NA` values
-    #'   last. Tied values (this includes `NA` values) appear in a random,
+    #'   last. The more important the feature, the higher the score.
+    #'   Tied values (this includes `NA` values) appear in a random,
     #'   non-deterministic order.
     scores = NULL,
 

--- a/R/FilterCMIM.R
+++ b/R/FilterCMIM.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterCMIM = R6Class("FilterCMIM",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::CMIM(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::CMIM(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterDISR.R
+++ b/R/FilterDISR.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterDISR = R6Class("FilterDISR",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::DISR(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::DISR(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterJMI.R
+++ b/R/FilterJMI.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterJMI = R6Class("FilterJMI",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::JMI(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::JMI(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterJMIM.R
+++ b/R/FilterJMIM.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterJMIM = R6Class("FilterJMIM",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::JMIM(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::JMIM(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterMIM.R
+++ b/R/FilterMIM.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterMIM = R6Class("FilterMIM",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::MIM(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::MIM(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterMRMR.R
+++ b/R/FilterMRMR.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -42,7 +43,7 @@ FilterMRMR = R6Class("FilterMRMR",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::MRMR(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::MRMR(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/FilterNJMIM.R
+++ b/R/FilterNJMIM.R
@@ -7,6 +7,7 @@
 #'
 #' This filter supports partial scoring (see [Filter]).
 #'
+#' @template details_praznik
 #' @family Filter
 #' @template seealso_filter
 #' @export
@@ -41,7 +42,7 @@ FilterNJMIM = R6Class("FilterNJMIM",
       threads = self$param_set$values$threads %??% 0L
       X = task$data(cols = task$feature_names)
       Y = task$truth()
-      praznik::NJMIM(X = X, Y = Y, k = nfeat, threads = threads)$score
+      reencode_praznik_score(praznik::NJMIM(X = X, Y = Y, k = nfeat, threads = threads))
     }
   )
 )

--- a/R/helper.R
+++ b/R/helper.R
@@ -1,0 +1,5 @@
+reencode_praznik_score = function(x) {
+  scores = x$score
+  n = length(scores)
+  set_names(rev(seq_len(n)) / n, names(scores))
+}

--- a/R/helper.R
+++ b/R/helper.R
@@ -1,5 +1,4 @@
 reencode_praznik_score = function(x) {
   scores = x$score
-  n = length(scores)
-  set_names(rev(seq_len(n)) / n, names(scores))
+  set_names(seq(from = 1, to = 0, length.out = length(scores)), names(scores))
 }

--- a/man-roxygen/details_praznik.R
+++ b/man-roxygen/details_praznik.R
@@ -1,0 +1,4 @@
+#' @details
+#' As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+#' to the greedy forward fashion, the returned scores simply reflect the selection order:
+#' `1`, `(n-1)/n`, ..., `1/n` where `n` is the number of features in the task.

--- a/man-roxygen/details_praznik.R
+++ b/man-roxygen/details_praznik.R
@@ -1,4 +1,4 @@
 #' @details
 #' As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 #' to the greedy forward fashion, the returned scores simply reflect the selection order:
-#' `1`, `(n-1)/n`, ..., `1/n` where `n` is the number of features in the task.
+#' `1`, `(k-1)/k`, ..., `1/k` where `k` is the number of selected features.

--- a/man/Filter.Rd
+++ b/man/Filter.Rd
@@ -71,7 +71,8 @@ Defaults to \code{NA}, but can be set by child classes.}
 
 \item{\code{scores}}{Stores the calculated filter score values as named numeric vector.
 The vector is sorted in decreasing order with possible \code{NA} values
-last. Tied values (this includes \code{NA} values) appear in a random,
+last. The more important the feature, the higher the score.
+Tied values (this includes \code{NA} values) appear in a random,
 non-deterministic order.}
 }
 \if{html}{\out{</div>}}

--- a/man/mlr_filters_cmim.Rd
+++ b/man/mlr_filters_cmim.Rd
@@ -10,6 +10,11 @@ calling \code{\link[praznik:CMIM]{praznik::CMIM()}} from package \CRANpkg{prazni
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("cmim")

--- a/man/mlr_filters_cmim.Rd
+++ b/man/mlr_filters_cmim.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_disr.Rd
+++ b/man/mlr_filters_disr.Rd
@@ -10,6 +10,11 @@ Double input symmetrical relevance filter calling
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("disr")

--- a/man/mlr_filters_disr.Rd
+++ b/man/mlr_filters_disr.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_jmi.Rd
+++ b/man/mlr_filters_jmi.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_jmi.Rd
+++ b/man/mlr_filters_jmi.Rd
@@ -10,6 +10,11 @@ package \CRANpkg{praznik}.
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("jmi")

--- a/man/mlr_filters_jmim.Rd
+++ b/man/mlr_filters_jmim.Rd
@@ -10,6 +10,11 @@ Minimal joint mutual information maximisation filter calling
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("jmim")

--- a/man/mlr_filters_jmim.Rd
+++ b/man/mlr_filters_jmim.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_mim.Rd
+++ b/man/mlr_filters_mim.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_mim.Rd
+++ b/man/mlr_filters_mim.Rd
@@ -10,6 +10,11 @@ calling \code{\link[praznik:MIM]{praznik::MIM()}} in package \CRANpkg{praznik}.
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("mim")

--- a/man/mlr_filters_mrmr.Rd
+++ b/man/mlr_filters_mrmr.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_mrmr.Rd
+++ b/man/mlr_filters_mrmr.Rd
@@ -10,6 +10,11 @@ Minimum redundancy maximal relevancy filter calling
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("mrmr")

--- a/man/mlr_filters_njmim.Rd
+++ b/man/mlr_filters_njmim.Rd
@@ -10,6 +10,11 @@ calling \code{\link[praznik:NJMIM]{praznik::NJMIM()}} from package \CRANpkg{praz
 
 This filter supports partial scoring (see \link{Filter}).
 }
+\details{
+As the scores calculated by the \CRANpkg{praznik} package are not monotone due
+to the greedy forward fashion, the returned scores simply reflect the selection order:
+\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+}
 \examples{
 task = mlr3::tsk("iris")
 filter = flt("njmim")

--- a/man/mlr_filters_njmim.Rd
+++ b/man/mlr_filters_njmim.Rd
@@ -13,7 +13,7 @@ This filter supports partial scoring (see \link{Filter}).
 \details{
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
-\code{1}, \code{(n-1)/n}, ..., \code{1/n} where \code{n} is the number of features in the task.
+\code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
 }
 \examples{
 task = mlr3::tsk("iris")


### PR DESCRIPTION
@bommert reported that we re-introduced a bug we had already fixed in mlr. The praznik scores are not monotone in the selected features due to their iterative fashion. E.g., the first selected feature can have a score of 5, the second selected feature a score of 10. This PR replaces the praznik scores by a simple sequence.