### PR TITLE
Disable threading, tag hyperpars

### DIFF
--- a/R/FilterCMIM.R
+++ b/R/FilterCMIM.R
@@ -24,8 +24,9 @@ FilterCMIM = R6Class("FilterCMIM",
     #' @description Create a FilterCMIM object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
 
       super$initialize(
         id = "cmim",
@@ -40,10 +41,7 @@ FilterCMIM = R6Class("FilterCMIM",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::CMIM(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::CMIM)
     }
   )
 )

--- a/R/FilterDISR.R
+++ b/R/FilterDISR.R
@@ -24,8 +24,9 @@ FilterDISR = R6Class("FilterDISR",
     #' @description Create a FilterDISR object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
 
       super$initialize(
         id = "disr",
@@ -40,10 +41,7 @@ FilterDISR = R6Class("FilterDISR",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::DISR(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::DISR)
     }
   )
 )

--- a/R/FilterInformationGain.R
+++ b/R/FilterInformationGain.R
@@ -41,7 +41,7 @@ FilterInformationGain = R6Class("FilterInformationGain",
           default = "infogain"),
         ParamLgl$new("equal", default = FALSE),
         ParamLgl$new("discIntegers", default = TRUE),
-        ParamInt$new("threads", lower = 0L, default = 1L)
+        ParamInt$new("threads", lower = 1L, default = 1L, tags = "threads")
       ))
 
       super$initialize(

--- a/R/FilterJMI.R
+++ b/R/FilterJMI.R
@@ -24,8 +24,9 @@ FilterJMI = R6Class("FilterJMI",
     #' @description Create a FilterJMI object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
 
       super$initialize(
         id = "jmi",
@@ -40,10 +41,7 @@ FilterJMI = R6Class("FilterJMI",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::JMI(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::JMI)
     }
   )
 )

--- a/R/FilterJMIM.R
+++ b/R/FilterJMIM.R
@@ -25,8 +25,9 @@ FilterJMIM = R6Class("FilterJMIM",
     initialize = function() {
 
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
       super$initialize(
         id = "jmim",
         task_type = c("classif", "regr"),
@@ -40,10 +41,7 @@ FilterJMIM = R6Class("FilterJMIM",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::JMIM(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::JMIM)
     }
   )
 )

--- a/R/FilterMIM.R
+++ b/R/FilterMIM.R
@@ -24,8 +24,9 @@ FilterMIM = R6Class("FilterMIM",
     #' @description Create a FilterMIM object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
 
       super$initialize(
         id = "mim",
@@ -40,10 +41,7 @@ FilterMIM = R6Class("FilterMIM",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::MIM(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::MIM)
     }
   )
 )

--- a/R/FilterMRMR.R
+++ b/R/FilterMRMR.R
@@ -24,8 +24,9 @@ FilterMRMR = R6Class("FilterMRMR",
     #' @description Create a FilterMRMR object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
 
       super$initialize(
         id = "mrmr",
@@ -40,10 +41,7 @@ FilterMRMR = R6Class("FilterMRMR",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::MRMR(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::MRMR)
     }
   )
 )

--- a/R/FilterNJMIM.R
+++ b/R/FilterNJMIM.R
@@ -24,8 +24,9 @@ FilterNJMIM = R6Class("FilterNJMIM",
     #' @description Create a FilterNJMIM object.
     initialize = function() {
       param_set = ParamSet$new(list(
-        ParamInt$new("threads", lower = 0L, default = 0L)
+        ParamInt$new("threads", lower = 0L, default = 0L, tags = "threads")
       ))
+      param_set$values = list(threads = 1L)
       super$initialize(
         id = "njmim",
         task_type = c("classif", "regr"),
@@ -39,10 +40,7 @@ FilterNJMIM = R6Class("FilterNJMIM",
 
   private = list(
     .calculate = function(task, nfeat) {
-      threads = self$param_set$values$threads %??% 0L
-      X = task$data(cols = task$feature_names)
-      Y = task$truth()
-      reencode_praznik_score(praznik::NJMIM(X = X, Y = Y, k = nfeat, threads = threads))
+      call_praznik(self, task, praznik::NJMIM)
     }
   )
 )

--- a/R/helper.R
+++ b/R/helper.R
@@ -1,4 +1,9 @@
-reencode_praznik_score = function(x) {
-  scores = x$score
-  set_names(seq(from = 1, to = 0, length.out = length(scores)), names(scores))
+call_praznik = function(self, task, fun) {
+  selection = invoke(fun,
+    X = task$data(cols = task$feature_names),
+    Y = task$truth(),
+    .args = self$param_set$get_values()
+  )$selection
+
+  set_names(seq(from = 1, to = 0, length.out = length(selection)), names(selection))
 }

--- a/man-roxygen/details_praznik.R
+++ b/man-roxygen/details_praznik.R
@@ -2,3 +2,7 @@
 #' As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 #' to the greedy forward fashion, the returned scores simply reflect the selection order:
 #' `1`, `(k-1)/k`, ..., `1/k` where `k` is the number of selected features.
+#'
+#' Threading is disabled by default (hyperparameter `threads` is set to 1).
+#' Set to a number `>= 2` to enable threading, or to `0` for auto-detecting the number
+#' of available cores.

--- a/man/mlr_filters_cmim.Rd
+++ b/man/mlr_filters_cmim.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_disr.Rd
+++ b/man/mlr_filters_disr.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_jmi.Rd
+++ b/man/mlr_filters_jmi.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_jmim.Rd
+++ b/man/mlr_filters_jmim.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_mim.Rd
+++ b/man/mlr_filters_mim.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_mrmr.Rd
+++ b/man/mlr_filters_mrmr.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")

--- a/man/mlr_filters_njmim.Rd
+++ b/man/mlr_filters_njmim.Rd
@@ -14,6 +14,10 @@ This filter supports partial scoring (see \link{Filter}).
 As the scores calculated by the \CRANpkg{praznik} package are not monotone due
 to the greedy forward fashion, the returned scores simply reflect the selection order:
 \code{1}, \code{(k-1)/k}, ..., \code{1/k} where \code{k} is the number of selected features.
+
+Threading is disabled by default (hyperparameter \code{threads} is set to 1).
+Set to a number \verb{>= 2} to enable threading, or to \code{0} for auto-detecting the number
+of available cores.
 }
 \examples{
 task = mlr3::tsk("iris")


### PR DESCRIPTION
Threads are disabled to avoid conflicting parallelization techniques. The respective hyperparameters are tagged so that we can set them easily with new mlr3 helper function `set_threads()`. 