### PR TITLE
Support nested learners via base_learner()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     backports,
     checkmate,
     data.table,
-    mlr3 (>= 0.1.8),
+    mlr3 (>= 0.12.0),
     mlr3misc,
     paradox,
     R6

--- a/R/FilterImportance.R
+++ b/R/FilterImportance.R
@@ -47,7 +47,7 @@ FilterImportance = R6Class("FilterImportance",
     .calculate = function(task, nfeat) {
       learner = self$learner$clone(deep = TRUE)
       learner = learner$train(task = task)
-      learner$importance()
+      learner$base_learner()$importance()
     }
   )
 )


### PR DESCRIPTION
Paves the way to use `GraphLearner` or `AutoTune` for `FilterImportance` by accessing the wrapped base learner (not yet completely supported, but already not worse than the current situation).