### PR TITLE
Allow NA as task type

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -49,7 +49,7 @@ Filter = R6Class("Filter",
     #'   Identifier for the filter.
     #' @param task_type (`character()`)\cr
     #'   Types of the task the filter can operator on. E.g., `"classif"` or
-    #'   `"regr"`.
+    #'   `"regr"`. Can be set to `NA` to allow all task types.
     #' @param param_set ([paradox::ParamSet])\cr
     #'   Set of hyperparameters.
     #' @param feature_types (`character()`)\cr
@@ -73,8 +73,10 @@ Filter = R6Class("Filter",
       packages = character(), man = NA_character_) {
 
       self$id = assert_string(id)
-      self$task_type = assert_subset(task_type, mlr_reflections$task_types$type,
-        empty.ok = FALSE)
+      if (!test_scalar_na(task_type)) {
+        assert_subset(task_type, mlr_reflections$task_types$type, empty.ok = FALSE)
+      }
+      self$task_type = task_type
       self$task_properties = assert_subset(
         task_properties,
         unlist(mlr_reflections$task_properties, use.names = FALSE))
@@ -137,7 +139,9 @@ Filter = R6Class("Filter",
       task = assert_task(as_task(task),
         feature_types = self$feature_types,
         task_properties = self$task_properties)
-      assert_choice(task$task_type, self$task_type)
+      if (!test_scalar_na(self$task_type)) {
+        assert_choice(task$task_type, self$task_type)
+      }
       fn = task$feature_names
 
       if (task$nrow == 0L) {

--- a/R/FilterVariance.R
+++ b/R/FilterVariance.R
@@ -35,7 +35,7 @@ FilterVariance = R6Class("FilterVariance",
 
       super$initialize(
         id = "variance",
-        task_type = c("classif", "regr"),
+        task_type = NA_character_,
         param_set = param_set,
         packages = "stats",
         feature_types = c("integer", "numeric"),

--- a/man-roxygen/field_task_type.R
+++ b/man-roxygen/field_task_type.R
@@ -1,5 +1,6 @@
 #' @field task_type (`character(1)`)\cr
 #' Task type, e.g. `"classif"` or `"regr"`.
+#' Can be set to `NA` to allow all task types.
 #'
 #' For a complete list of possible task types (depending on the loaded packages),
 #' see [`mlr_reflections$task_types$type`][mlr_reflections].

--- a/man/Filter.Rd
+++ b/man/Filter.Rd
@@ -50,6 +50,7 @@ Used in tables, plot and text output.}
 
 \item{\code{task_type}}{(\code{character(1)})\cr
 Task type, e.g. \code{"classif"} or \code{"regr"}.
+Can be set to \code{NA} to allow all task types.
 
 For a complete list of possible task types (depending on the loaded packages),
 see \code{\link[=mlr_reflections]{mlr_reflections$task_types$type}}.}
@@ -114,7 +115,7 @@ Identifier for the filter.}
 
 \item{\code{task_type}}{(\code{character()})\cr
 Types of the task the filter can operator on. E.g., \code{"classif"} or
-\code{"regr"}.}
+\code{"regr"}. Can be set to \code{NA} to allow all task types.}
 
 \item{\code{task_properties}}{(\code{character()})\cr
 Required task properties, see \link[mlr3:Task]{mlr3::Task}.


### PR DESCRIPTION
Variance does not require a target, so this should also work with clustering or survival tasks.