### PR TITLE
fix small initialization bug

### DIFF
--- a/R/FilterVariance.R
+++ b/R/FilterVariance.R
@@ -43,7 +43,7 @@ FilterVariance = R6Class("FilterVariance",
       param_set = ps(
         na.rm = p_lgl(default = TRUE)
       )
-      self$param_set$values = list(na.rm = TRUE)
+      param_set$values = list(na.rm = TRUE)
 
       super$initialize(
         id = "variance",


### PR DESCRIPTION
`na.rm` parameter was initialized to NULL making the variance filter not usable by default on tasks with missing features => now it's initialized properly to `TRUE` :)