### PR TITLE
fix:: calculating hash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Added `FilterUnivariateCox` (thanks to @bblodfon)
 - Parameter value `na.rm` is properly initialized to `TRUE` (thanks to @bblodfon)
 - Bugfix: property `missings` is now set correctly for `FilterFindCorrelation`
+- Bugfix: `$hash` now works for `Filter`s
 
 # mlr3filters 0.7.1
 

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -229,6 +229,10 @@ Filter = R6Class("Filter",
       assert_ro_binding(rhs)
       calculate_hash(class(self), self$id, mget(private$.extra_hash, envir = self))
     }
+  ),
+
+  private = list(
+    .extra_hash = character()
   )
 )
 


### PR DESCRIPTION
fixes #162

Currently, no Filter overwrites `private$.extra_hash`, so it could also be removed. Leaving it in for now, to leave the option open for the future.